### PR TITLE
GC-27 feat：選擇專案會顯示對應專案 data

### DIFF
--- a/src/component/GanttArea/index.jsx
+++ b/src/component/GanttArea/index.jsx
@@ -1,6 +1,8 @@
 import { Box, Divider } from '@mui/material';
 import { Gantt } from 'gantt-task-react';
+import { useLoaderData } from 'react-router-dom';
 import React from 'react'
+import { getGanttData } from '../../functions/getGanttData';
 
 import "gantt-task-react/dist/index.css";
 
@@ -122,10 +124,32 @@ const testData = [
 ]
 
 const GanttArea = () => {
+  const ganttData = useLoaderData();
+  console.log('ganttData from useLoaderData', ganttData);
   return (
     <Box sx={{width: '100%', }}>
       {
-        testData.map((projects, idx) => {
+        (ganttData[0].list.length !== 0) ? (
+          ganttData.map((projects, idx) => {
+            return (
+              <Box key={idx} sx={{maxWidth: '90%', ml: 'auto', mr: 'auto', }}>
+                <h3>{projects.projectName}</h3>
+                <Gantt tasks={projects.list} />
+                <Divider />
+              </Box>
+            )
+          })) : (
+          ganttData.map((projects, idx) => {
+            return (
+              <Box key={idx} sx={{maxWidth: '90%', ml: 'auto', mr: 'auto', }}>
+                <h3>{projects.projectName}</h3>
+                <p>Sorry, no data here!</p>
+                <Divider />
+              </Box>
+            )
+          }))
+      }
+        {/* ganttData.map((projects, idx) => {
           return (
             <Box key={idx} sx={{maxWidth: '90%', ml: 'auto', mr: 'auto', }}>
               <h3>{projects.projectName}</h3>
@@ -133,10 +157,16 @@ const GanttArea = () => {
               <Divider />
             </Box>
           )
-        })
-      }
+        }) */}
+      {/* } */}
     </Box>
   )
 }
 
 export default GanttArea;
+
+export const loader = async({ params }) => {
+  const projectName = params.name;
+  const ganttData = await getGanttData(projectName);
+  return ganttData;
+};

--- a/src/component/InputArea/index.jsx
+++ b/src/component/InputArea/index.jsx
@@ -53,6 +53,7 @@ const InputArea = ({ ganttData, setGanttData }) => {
       console.log('project not found!')
     );
     setGanttData(newList);
+    localStorage.setItem("ganttDatas", JSON.stringify(ganttData));
     console.log('ganttData', ganttData);
     setTaskData({
       id: null,

--- a/src/functions/getGanttData.js
+++ b/src/functions/getGanttData.js
@@ -1,0 +1,19 @@
+export const getGanttData = async(id) => {
+  const ganttDatas = await localStorage.getItem("ganttDatas");
+  const ganttData = JSON.parse(ganttDatas);
+  const result = ganttData.some(project => id === project.name);
+  if (!result) {
+    console.log('something went wrong in the getGanttData session, plz check...');
+  } else {
+    const filteredGanttData = ganttData.filter(project => project.name === id);
+    const dataList = filteredGanttData[0].list;
+    filteredGanttData[0].list = dataList.map(task => {
+      return {
+        ...task,
+        start: new Date(task.start),
+        end: new Date(task.end),
+      }
+    })
+    return filteredGanttData;
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import GanttArea from './component/GanttArea';
+import GanttArea,  { loader as ganttDataLoader } from './component/GanttArea';
 import ErrorPage from './component/ErrorPage';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -16,6 +16,7 @@ const route = createBrowserRouter([
       {
         path: 'projects/:name',
         element: <GanttArea />,
+        loader: ganttDataLoader,
       },
     ]
   }


### PR DESCRIPTION
問題：
1. 先前版本只能一次顯示全部，無法針對個別專案顯示該專案內容。
2. 時間格式顯示錯誤。

原因：
1. 沒有處理好 react router <Outlet /> 的 loadingData。
2. 從 JSON 格式轉換過來，需重新調整時間格式。

解決方法：
1. 更新 ganttData state 後，一律優先更新至 localstorage，接著透過 react router loader 來綁定對應的 async function，這樣就能讀取 localstorage 的資料。
2. 在抓取資料的 async function 內直接重新設定各個 task 的時間格式。