### PR TITLE
GC-26 feat：主頁 index 可顯示所有 Gantt 資料

### DIFF
--- a/src/component/TotalViewGanttArea/index.jsx
+++ b/src/component/TotalViewGanttArea/index.jsx
@@ -1,0 +1,42 @@
+import { Box, Divider } from '@mui/material';
+import { Gantt } from 'gantt-task-react';
+import React from 'react';
+import { useLoaderData } from 'react-router-dom';
+import { getTotalGanttData } from '../../functions/getGanttData';
+
+const TotalViewGanttArea = () => {
+  const totalViewGanttData = useLoaderData();
+  return (
+    <Box sx={{width: '100%', }}>
+      {
+        (totalViewGanttData[0].list.length !== 0) ? (
+          totalViewGanttData.map((projects, idx) => {
+            return (
+              <Box key={idx} sx={{maxWidth: '90%', ml: 'auto', mr: 'auto', }}>
+                <h3>{projects.projectName}</h3>
+                <Gantt tasks={projects.list} />
+                <Divider />
+              </Box>
+            )
+          })) : (
+            totalViewGanttData.map((projects, idx) => {
+            return (
+              <Box key={idx} sx={{maxWidth: '90%', ml: 'auto', mr: 'auto', }}>
+                <h3>{projects.projectName}</h3>
+                <p>Sorry, no data here!</p>
+                <Divider />
+              </Box>
+            )
+          }))
+      }
+    </Box>
+  )
+}
+
+export default TotalViewGanttArea;
+
+
+export const loader = async() => {
+  const ganttData = await getTotalGanttData();
+  return ganttData;
+};

--- a/src/functions/getGanttData.js
+++ b/src/functions/getGanttData.js
@@ -17,3 +17,23 @@ export const getGanttData = async(id) => {
     return filteredGanttData;
   };
 };
+
+export const getTotalGanttData = async() => {
+  const ganttDatas = await localStorage.getItem("ganttDatas");
+  const ganttData = JSON.parse(ganttDatas);
+  const newData = ganttData.map(project => {
+    return {
+      ...project,
+      list: project.list.map(task => {
+        console.log(task);
+        return {
+          ...task,
+          start: new Date(task.start),
+          end: new Date(task.end),
+        };
+      }),
+    }
+  });
+  console.log(newData);
+  return newData;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import TotalViewGanttArea, { loader as totalViewGanttDataLoader } from './component/TotalViewGanttArea';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import GanttArea,  { loader as ganttDataLoader } from './component/GanttArea';
 import ErrorPage from './component/ErrorPage';
@@ -17,6 +18,11 @@ const route = createBrowserRouter([
         path: 'projects/:name',
         element: <GanttArea />,
         loader: ganttDataLoader,
+      },
+      {
+        index: true,
+        element: <TotalViewGanttArea />,
+        loader: totalViewGanttDataLoader,
       },
     ]
   }


### PR DESCRIPTION
問題：
1. 主頁無法顯示所有專案的 Gantt 圖。

原因：
1. 沒有設定 react router 的 index。

解決方法：
1. 製作新的 component：TotalViewGanttArea。
2. 接著設定 <App /> react router 的 index，並連接 loader 即可。