### PR TITLE
GC-37 fix：Error 404 Page 元素垂直置中

### DIFF
--- a/src/component/ErrorPage/index.jsx
+++ b/src/component/ErrorPage/index.jsx
@@ -1,22 +1,41 @@
-import { Box, Button } from "@mui/material";
-import { Link, useRouteError } from "react-router-dom";
+import { Box, Button } from '@mui/material';
+import { Link, useRouteError } from 'react-router-dom';
 
 const errorImg = require('../../assets/404_Error_bgImg.png');
 
 const ErrorPage = () => {
-  const error = useRouteError();
+	const error = useRouteError();
 
-  return (
-    <Box sx={{width: '100%', textAlign: 'center', height: '100', }}>
-      <div style={{margin: 'auto', display: 'block',}} >
-        <img src={errorImg} alt='404 Error' style={{marginLeft: 'auto', marginRight: 'auto', }} />
-        <p style={{fontSize: '24px', }}>Oops...Page <i>{error.statusText || error.message}!</i></p>
-        <Link to={'/'} style={{textDecoration: 'none', color: 'inherit'}}>
-          <Button size='large'>點擊我回到主頁</Button>
-        </Link>
-      </div>
-    </Box>
-  )
-}
+	return (
+		<Box
+			sx={{
+				width: '100%',
+				textAlign: 'center',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					flexWrap: 'wrap',
+					width: '100%',
+					height: '100vh',
+					margin: 'auto',
+				}}>
+				<img
+					src={errorImg}
+					alt='404 Error'
+					style={{ margin: 'auto', width: '40%', display: 'block' }}
+				/>
+				<div style={{ marginLeft: 'auto', marginRight: 'auto', width: '100%' }}>
+					<p style={{ fontSize: '24px' }}>
+						Oops...Page <i>{error.statusText || error.message}!</i>
+					</p>
+					<Link to={'/'} style={{ textDecoration: 'none', color: 'inherit' }}>
+						<Button size='large'>點擊我回到主頁</Button>
+					</Link>
+				</div>
+			</div>
+		</Box>
+	);
+};
 
 export default ErrorPage;


### PR DESCRIPTION
問題：
1. 原本無法垂直置中

解決方法：
1. 透過設置父元素 display 為 flex，並開啟 flex-wrap，並將文字區塊 width 調成 100%，並左右 margin 設定為 auto，即完成垂直置中。