### PR TITLE
GC-54 feat：完成新增專案 input focus

### DIFF
--- a/src/component/Sidebar/CreateListItem/CreateForm.js
+++ b/src/component/Sidebar/CreateListItem/CreateForm.js
@@ -15,7 +15,7 @@ import { addProjectIntoGanttData } from '../../../store/ganttDataSlice';
 
 const CreateForm = ({ clickCreate, setClickCreate }) => {
 	const cancelCreateHandler = () => setClickCreate(!clickCreate);
-	const [isInputError, setIsInputError] = useState(false);
+	const [isInputError, setIsInputError] = useState(true);
 	const dispatch = useDispatch();
 	const ganttCatData = useSelector((state) => state.ganttDataRedux);
 
@@ -74,6 +74,7 @@ const CreateForm = ({ clickCreate, setClickCreate }) => {
 						label='新事項名稱'
 						placeholder='輸入新事項名稱...'
 						onChange={inputHandler}
+						autoFocus='true'
 					/>
 				</FormControl>
 				<ListItem sx={{ pl: 0, pr: 0, maxWidth: '60px' }}>


### PR DESCRIPTION
問題：
1. 發現使用者試用時點擊「新增專案」後，還得在點擊一次 input，才可以輸入專案名稱

原因：
1. 沒有設置 input focus

解決辦法：
1. 設定 MUI Input autoFocus = 'true'
2. 並將 isInputError state 預設為 'true'，好解決點擊新增專案，可以直接點選「+」的問題