### PR TITLE
GC-64 fix：修正手動刪除日期會跳錯一事

### DIFF
--- a/src/component/InputArea/index.jsx
+++ b/src/component/InputArea/index.jsx
@@ -139,10 +139,11 @@ const InputArea = () => {
 									label='Start Date'
 									value={taskData.start}
 									onChange={(startDate) => {
-										setTaskData({
-											...taskData,
-											start: startDate.$d,
-										});
+										startDate !== null &&
+											setTaskData({
+												...taskData,
+												start: startDate.$d,
+											});
 										if (taskData.end !== null) {
 											setIsDateNotValid(false);
 										}
@@ -159,10 +160,11 @@ const InputArea = () => {
 									label='Deadline'
 									value={taskData.end}
 									onChange={(deadline) => {
-										setTaskData({
-											...taskData,
-											end: deadline.$d,
-										});
+										deadline !== null &&
+											setTaskData({
+												...taskData,
+												end: deadline.$d,
+											});
 										if (taskData.start !== null) {
 											setIsDateNotValid(false);
 										}


### PR DESCRIPTION
問題：
1. 使用者刪除日期會跳錯，直接導致 Error 404 Page。

原因：
1. startDate & deadline 2 者在使用者刪除日期後，為 null

解決方法：
1. 設定條件式，只有當 startDate & deadline 2 者不等於 null 時，才會 setState。