### PR TITLE
GC-71 feat：可以調整時間刻度

### DIFF
--- a/src/component/GanttArea/GanttGroup.js
+++ b/src/component/GanttArea/GanttGroup.js
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
-import { Gantt } from 'gantt-task-react';
+import { Gantt, ViewMode } from 'gantt-task-react';
 import React from 'react';
 import 'gantt-task-react/dist/index.css';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
 	deleteTaskFromGanttData,
 	editTaskNameInGanttData,
@@ -10,6 +10,16 @@ import {
 
 export const GanttGroup = ({ project }) => {
 	const dispatch = useDispatch();
+	const timeView = useSelector((state) => state.timeView);
+
+	let columnWidth = 65;
+	if (timeView.view === ViewMode.Year) {
+		columnWidth = 350;
+	} else if (timeView.view === ViewMode.Month) {
+		columnWidth = 300;
+	} else if (timeView.view === ViewMode.Week) {
+		columnWidth = 250;
+	}
 
 	const deleteTaskHandler = (task) => {
 		const conf = window.confirm(`Are you sure about delete ${task.name} ?`);
@@ -37,6 +47,8 @@ export const GanttGroup = ({ project }) => {
 					tasks={project.list}
 					onDelete={deleteTaskHandler}
 					onDoubleClick={editTaskHandler}
+					viewMode={timeView.view}
+					columnWidth={columnWidth}
 				/>
 			) : (
 				<p>There's no data yet!</p>

--- a/src/component/InputArea/index.jsx
+++ b/src/component/InputArea/index.jsx
@@ -14,6 +14,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { v4 as uuidv4 } from 'uuid';
 import { useDispatch, useSelector } from 'react-redux';
 import { addTaskIntoGanttData } from '../../store/ganttDataSlice';
+import { changeView } from '../../store/timeViewSlice';
 
 import { useState } from 'react';
 
@@ -71,8 +72,17 @@ const InputArea = () => {
 		}
 	};
 
+	const timeViewHandler = (e) => {
+		const time = e.target.value;
+		dispatch(
+			changeView({
+				view: time,
+			})
+		);
+	};
+
 	return (
-		<Box sx={{ width: '100%', display: 'flex' }}>
+		<Box sx={{ width: '100%', display: 'flex', flexWrap: 'wrap' }}>
 			<Box
 				sx={{
 					width: '90%',
@@ -97,7 +107,7 @@ const InputArea = () => {
 						flexWrap: 'wrap',
 					}}>
 					<Stack direction='row' spacing={2.5} sx={{ position: 'relative' }}>
-						<FormControl sx={{ minWidth: '150px' }} required='true'>
+						<FormControl sx={{ minWidth: '150px' }} required={true}>
 							<InputLabel htmlFor='component-outlined'>Task Name</InputLabel>
 							<OutlinedInput
 								id='component-outlined'
@@ -107,7 +117,7 @@ const InputArea = () => {
 								value={taskData.name}
 							/>
 						</FormControl>
-						<FormControl sx={{ minWidth: '150px' }} required='true'>
+						<FormControl sx={{ minWidth: '150px' }} required={true}>
 							<InputLabel>Project Name</InputLabel>
 							<Select
 								label='Project Name'
@@ -122,7 +132,7 @@ const InputArea = () => {
 								})}
 							</Select>
 						</FormControl>
-						<FormControl sx={{ minWidth: '150px' }} required='true'>
+						<FormControl sx={{ minWidth: '150px' }} required={true}>
 							<InputLabel>Task Type</InputLabel>
 							<Select
 								label='Task Type'
@@ -188,6 +198,39 @@ const InputArea = () => {
 						新增事項
 					</Button>
 				</form>
+			</Box>
+			<Box
+				sx={{
+					width: '90%',
+					display: 'flex',
+					flexDirection: 'row-reverse',
+					ml: 'auto',
+					mr: 'auto',
+				}}>
+				<FormControl
+					sx={{
+						minWidth: '150px',
+					}}>
+					<InputLabel>時間刻度</InputLabel>
+					<Select
+						label='時間刻度'
+						defaultValue='Day'
+						sx={{ borderRadius: 2 }}
+						onChange={timeViewHandler}>
+						<MenuItem value={'Day'} key={'Day'}>
+							Day
+						</MenuItem>
+						<MenuItem value={'Week'} key={'Week'}>
+							Week
+						</MenuItem>
+						<MenuItem value={'Month'} key={'Month'}>
+							Month
+						</MenuItem>
+						<MenuItem value={'Year'} key={'Year'}>
+							Year
+						</MenuItem>
+					</Select>
+				</FormControl>
 			</Box>
 		</Box>
 	);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import projectCatReducer from './projectCatSlice';
 import ganttDataSlice from './ganttDataSlice';
+import timeViewSlice from './timeViewSlice';
 
 export const store = configureStore({
 	reducer: {
 		projectCategories: projectCatReducer,
 		ganttDataRedux: ganttDataSlice,
+		timeView: timeViewSlice,
 	},
 });

--- a/src/store/timeViewSlice.js
+++ b/src/store/timeViewSlice.js
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+	view: 'Day',
+};
+
+export const timeViewSlice = createSlice({
+	name: 'timeView',
+	initialState,
+	reducers: {
+		changeView: (state, action) => {
+			state.view = action.payload.view;
+		},
+	},
+});
+
+export const { changeView } = timeViewSlice.actions;
+
+export default timeViewSlice.reducer;


### PR DESCRIPTION
問題：
1. 使用者需要使用滾軸才能查看該專案的全部甘特圖，若 task 時間過長無法一次看清全貌

原因：
1. 沒有設定 gantt-react-task 的 <Gantt> 時間刻度 viewMode。

解決方法：
1. 建立 timeView slice；
2. 設立選單可以設定 timeView，預設為 'Day' 模式。