### PR TITLE
GC-51 style：調整「開新專案」按鈕樣式

### DIFF
--- a/src/component/Sidebar/CreateListItem/CreateBtn.js
+++ b/src/component/Sidebar/CreateListItem/CreateBtn.js
@@ -1,23 +1,42 @@
-import { List, ListItem, ListItemButton, ListItemIcon, ListItemText } from "@mui/material";
-import { AddBox } from "@mui/icons-material";
+import {
+	List,
+	ListItem,
+	ListItemButton,
+	ListItemIcon,
+	ListItemText,
+} from '@mui/material';
+import { AddBoxOutlined } from '@mui/icons-material';
 
-const CreateBtn = ({ clickCreate, setClickCreate}) => {
-  const clickCreateHandler = () => {
-    setClickCreate(!clickCreate);
-  };
+const CreateBtn = ({ clickCreate, setClickCreate }) => {
+	const clickCreateHandler = () => {
+		setClickCreate(!clickCreate);
+	};
 
-  return (
-    <List>
-      <ListItem>
-        <ListItemButton onClick={clickCreateHandler}>
-          <ListItemIcon>
-            <AddBox />
-          </ListItemIcon>
-          <ListItemText primary="新增專案" />
-        </ListItemButton>
-      </ListItem>
-    </List>
-  )
-}
+	return (
+		<List>
+			<ListItem>
+				<ListItemButton
+					onClick={clickCreateHandler}
+					sx={{
+						backgroundColor: (theme) => theme.palette.other.btn,
+						borderRadius: 2,
+						'&.MuiButtonBase-root:hover': {
+							backgroundColor: '#5D5FEF !important',
+						},
+					}}>
+					<ListItemIcon>
+						<AddBoxOutlined
+							sx={{ color: (theme) => theme.palette.other.white }}
+						/>
+					</ListItemIcon>
+					<ListItemText
+						primary='新增專案'
+						sx={{ color: (theme) => theme.palette.other.white }}
+					/>
+				</ListItemButton>
+			</ListItem>
+		</List>
+	);
+};
 
 export default CreateBtn;

--- a/src/component/Sidebar/CreateListItem/CreateForm.js
+++ b/src/component/Sidebar/CreateListItem/CreateForm.js
@@ -74,7 +74,7 @@ const CreateForm = ({ clickCreate, setClickCreate }) => {
 						label='新事項名稱'
 						placeholder='輸入新事項名稱...'
 						onChange={inputHandler}
-						autoFocus='true'
+						autoFocus={true}
 					/>
 				</FormControl>
 				<ListItem sx={{ pl: 0, pr: 0, maxWidth: '60px' }}>


### PR DESCRIPTION
問題：
1. 使用者使用時一開始無從分辨「開新專案」可以點選，以為只是分頁。

原因：
1. 「開新專案」不明顯，明明是按鈕，卻沒有按鈕的設計樣式。

解決辦法：
1. 重新設定「開新專案」按鈕顏色
2. 重新調整「開新專案」AddIcon 樣式成 Outlined