### PR TITLE
GC-74 feat：使用者更改 project cat 時也一併更新 DB 對應資料

### DIFF
--- a/amplify/backend/function/projectCatsFunc/src/app.js
+++ b/amplify/backend/function/projectCatsFunc/src/app.js
@@ -149,17 +149,82 @@ app.get(path + '/object' + hashKeyPath + sortKeyPath, function (req, res) {
  * HTTP put method for insert object *
  *************************************/
 
-app.put(path, function (req, res) {
-	if (userIdPresent) {
-		req.body['userId'] =
+// app.put(path + '/:id', function (req, res) {
+// 	if (userIdPresent) {
+// 		req.body['userId'] =
+// 			req.apiGateway.event.requestContext.identity.cognitoIdentityId || UNAUTH;
+// 	}
+
+// 	let putItemParams = {
+// 		TableName: tableName,
+// 		Item: req.body,
+// 	};
+// 	dynamodb.put(putItemParams, (err, data) => {
+// 		if (err) {
+// 			res.statusCode = 500;
+// 			res.json({ error: err, url: req.url, body: req.body });
+// 		} else {
+// 			res.json({ success: 'put call succeed!', url: req.url, data: data });
+// 		}
+// 	});
+// });
+app.put(path + hashKeyPath + '/:id', function (req, res) {
+	const params = {
+		id: req.params.id,
+		// UpdateExpression: 'SET #name = :n, #updatedAt = :u',
+		// ExpressionAttributeNames: {
+		// 	'#name': 'name',
+		// 	'#updatedAt': 'updatedAt',
+		// },
+		// ExpressionAttributeValues: {
+		// 	':n': req.body.name,
+		// 	':u': req.body.updatedAt,
+		// },
+		// ReturnValues: 'UPDATED_NEW',
+	};
+	if (userIdPresent && req.apiGateway) {
+		params[partitionKeyName] =
 			req.apiGateway.event.requestContext.identity.cognitoIdentityId || UNAUTH;
+	} else {
+		params[partitionKeyName] = req.params[partitionKeyName];
+		try {
+			params[partitionKeyName] = convertUrlType(
+				req.params[partitionKeyName],
+				partitionKeyType
+			);
+		} catch (err) {
+			res.statusCode = 500;
+			res.json({ error: 'Wrong column type ' + err });
+		}
+	}
+	if (hasSortKey) {
+		try {
+			params[sortKeyName] = convertUrlType(
+				req.params[sortKeyName],
+				sortKeyType
+			);
+		} catch (err) {
+			res.statusCode = 500;
+			res.json({ error: 'Wrong column type ' + err });
+		}
 	}
 
 	let putItemParams = {
 		TableName: tableName,
-		Item: req.body,
+		Key: params,
+		// Item: req.body,
+		UpdateExpression: 'SET #name = :n, #updatedAt = :u',
+		ExpressionAttributeNames: {
+			'#name': 'name',
+			'#updatedAt': 'updatedAt',
+		},
+		ExpressionAttributeValues: {
+			':n': req.body.name,
+			':u': req.body.updatedAt,
+		},
+		ReturnValues: 'UPDATED_NEW',
 	};
-	dynamodb.put(putItemParams, (err, data) => {
+	dynamodb.update(putItemParams, (err, data) => {
 		if (err) {
 			res.statusCode = 500;
 			res.json({ error: err, url: req.url, body: req.body });

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -19,7 +19,7 @@
       "function": {
         "projectCatsFunc": {
           "deploymentBucketName": "amplify-ganttchartapp-dev-154534-deployment",
-          "s3Key": "amplify-builds/projectCatsFunc-783838436a436f423474-build.zip"
+          "s3Key": "amplify-builds/projectCatsFunc-4856507933714f432b43-build.zip"
         }
       },
       "storage": {

--- a/src/component/Sidebar/ChangeList/EditButton.js
+++ b/src/component/Sidebar/ChangeList/EditButton.js
@@ -22,14 +22,15 @@ export const EditButton = ({ project }) => {
 			};
 		}
 		console.log('editedCatName', editedCatName);
-		API.put('projectCats', '/projectcats/', {
+		API.put('projectCatsApi', `/projectcats/userId/${project.id}`, {
+			response: true,
 			body: {
 				name: editedCatName.name,
 				updatedAt: editedCatName.updatedAt,
 				id: projectCats.id,
 				createdAt: projectCats.createdAt,
 			},
-		});
+		}).then((res) => console.log(res));
 		dispatch(editProjectCat(editedCatName));
 		dispatch(editProjectInGanttData(editedCatName));
 	};


### PR DESCRIPTION
問題：
1. 使用者更新 project category 時，並不會更新 DynamoDB 的對應資料。

原因：
1. 沒有設置相關 put API、lamda function code 來更新 DynamoDB。

解決方法：
1. 設置相關 put API。
2. 更改 lamda function code 使其可以更新 DynamoDB。