### PR TITLE
GC-77 feat：刪除 Project Cat & task 皆會刪除資料庫對應 task(s)

### DIFF
--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -23,7 +23,7 @@
         },
         "ganttTasksFunc": {
           "deploymentBucketName": "amplify-ganttchartapp-dev-154534-deployment",
-          "s3Key": "amplify-builds/ganttTasksFunc-5773664c50644f303556-build.zip"
+          "s3Key": "amplify-builds/ganttTasksFunc-64735178635a5857526a-build.zip"
         }
       },
       "storage": {

--- a/src/component/GanttArea/GanttGroup.js
+++ b/src/component/GanttArea/GanttGroup.js
@@ -7,6 +7,7 @@ import {
 	deleteTaskFromGanttData,
 	editTaskNameInGanttData,
 } from '../../store/ganttDataSlice';
+import { API } from 'aws-amplify';
 
 export const GanttGroup = ({ project }) => {
 	const dispatch = useDispatch();
@@ -23,8 +24,13 @@ export const GanttGroup = ({ project }) => {
 	}
 
 	const deleteTaskHandler = (task) => {
+		console.log(task, 'task');
 		const conf = window.confirm(`Are you sure about delete ${task.name} ?`);
-		!!conf && dispatch(deleteTaskFromGanttData(task));
+		!!conf &&
+			API.del('ganttTasksApi', `/gantttasks/userId/${task.id}`, {
+				response: true,
+			}).then((response) => console.log(response, 'from del API')) &&
+			dispatch(deleteTaskFromGanttData(task));
 	};
 
 	const editTaskHandler = (task) => {

--- a/src/component/Sidebar/ChangeList/DeleteButton.js
+++ b/src/component/Sidebar/ChangeList/DeleteButton.js
@@ -2,18 +2,27 @@ import { DeleteOutline } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { API } from 'aws-amplify';
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { deleteProjectFromGanttData } from '../../../store/ganttDataSlice';
 import { deleteProjectCat } from '../../../store/projectCatSlice';
 
 export default function DeleteButton({ project }) {
 	const dispatch = useDispatch();
+	const ganttTasksData = useSelector((state) => state.ganttDataRedux);
 	const catDeleteHandler = (e) => {
 		console.log('try to delete so hard...');
 		e.preventDefault();
-		API.del('projectCatsApi', `/projectcats/userId/${project.id}`, {
-			response: true,
-		}).then((response) => console.log(response, 'from del API'));
+		// API.del('projectCatsApi', `/projectcats/userId/${project.id}`, {
+		// 	response: true,
+		// }).then((response) => console.log(response, 'from del cat API'));
+		const delProjectData = ganttTasksData.projects.filter(
+			(thisProject) => thisProject.id === project.id
+		);
+		delProjectData[0].list.forEach((task) => {
+			API.del('ganttTasksApi', `/gantttasks/userId/${task.id}`, {
+				response: true,
+			}).then((response) => console.log(response, 'from del task API'));
+		});
 		dispatch(deleteProjectCat(project.id));
 		dispatch(deleteProjectFromGanttData(project.id));
 	};

--- a/src/component/Sidebar/Sidebar.js
+++ b/src/component/Sidebar/Sidebar.js
@@ -48,7 +48,7 @@ const Sidebar = () => {
 		if (isDataFetchedRef.current) return;
 		const fetchData = async () => {
 			dispatch(fetchCats());
-			dispatch(fetchCatsToGantt());
+			await dispatch(fetchCatsToGantt());
 			await dispatch(fetchTasksToGantt());
 		};
 		fetchData();


### PR DESCRIPTION
問題：
1. 使用者刪除 task 時，DynamoDB 對應資料不會跟著刪除。
2. 使用者刪除 Project Cat 時，DynamoDB 對應資料不會跟著刪除。

原因：
1. 沒有設定 delete API

解決方法：
1. 設定 delete API。
2. 設定 lamda function。