### PR TITLE
GC-76 feat：使用者修改 task name 會一併更改 DB 對應資料

### DIFF
--- a/amplify/backend/function/ganttTasksFunc/src/app.js
+++ b/amplify/backend/function/ganttTasksFunc/src/app.js
@@ -153,10 +153,6 @@ app.put(path + hashKeyPath + '/:id', function (req, res) {
 	const params = {
 		id: req.params.id,
 	};
-	// if (userIdPresent) {
-	// 	req.body['userId'] =
-	// 		req.apiGateway.event.requestContext.identity.cognitoIdentityId || UNAUTH;
-	// }
 
 	if (userIdPresent && req.apiGateway) {
 		params[partitionKeyName] =
@@ -191,7 +187,6 @@ app.put(path + hashKeyPath + '/:id', function (req, res) {
 	let putItemParams = {
 		TableName: tableName,
 		Key: params,
-		// Item: req.body,
 		UpdateExpression: 'SET #name = :n, #updatedAt = :u',
 		ExpressionAttributeNames: {
 			'#name': 'name',
@@ -208,7 +203,7 @@ app.put(path + hashKeyPath + '/:id', function (req, res) {
 	// 	TableName: tableName,
 	// 	Item: req.body,
 	// };
-	dynamodb.put(putItemParams, (err, data) => {
+	dynamodb.update(putItemParams, (err, data) => {
 		if (err) {
 			res.statusCode = 500;
 			res.json({ error: err, url: req.url, body: req.body });

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -23,7 +23,7 @@
         },
         "ganttTasksFunc": {
           "deploymentBucketName": "amplify-ganttchartapp-dev-154534-deployment",
-          "s3Key": "amplify-builds/ganttTasksFunc-64735178635a5857526a-build.zip"
+          "s3Key": "amplify-builds/ganttTasksFunc-4b636b65496377617037-build.zip"
         }
       },
       "storage": {

--- a/src/component/GanttArea/GanttGroup.js
+++ b/src/component/GanttArea/GanttGroup.js
@@ -44,6 +44,11 @@ export const GanttGroup = ({ project }) => {
 				id: task.id,
 			};
 		}
+		API.put('ganttTasksApi', `/gantttasks/userId/${task.id}`, {
+			body: {
+				name: editedTask.name,
+			},
+		});
 		dispatch(editTaskNameInGanttData(editedTask));
 	};
 

--- a/src/component/Sidebar/ChangeList/DeleteButton.js
+++ b/src/component/Sidebar/ChangeList/DeleteButton.js
@@ -12,9 +12,9 @@ export default function DeleteButton({ project }) {
 	const catDeleteHandler = (e) => {
 		console.log('try to delete so hard...');
 		e.preventDefault();
-		// API.del('projectCatsApi', `/projectcats/userId/${project.id}`, {
-		// 	response: true,
-		// }).then((response) => console.log(response, 'from del cat API'));
+		API.del('projectCatsApi', `/projectcats/userId/${project.id}`, {
+			response: true,
+		}).then((response) => console.log(response, 'from del cat API'));
 		const delProjectData = ganttTasksData.projects.filter(
 			(thisProject) => thisProject.id === project.id
 		);


### PR DESCRIPTION
問題：
1. 使用者更新 task name 時，DynamoDB 不會更新 task name。

原因：
1. 沒有 put API。

解決方法：
1. 設置對應 lambda function、put API，讓使用者更改 task name 後，一同修改 DynamoDB 的 task name 與 updatedAt。