### PR TITLE
GC-101 feat：用戶更改 task 名稱一併更改 Calendar Event 名稱

### DIFF
--- a/src/component/GanttArea/GanttGroup.js
+++ b/src/component/GanttArea/GanttGroup.js
@@ -11,6 +11,7 @@ import { API } from 'aws-amplify';
 
 export const GanttGroup = ({ project }) => {
 	const dispatch = useDispatch();
+	const userData = useSelector((state) => state.userData.userData);
 	const timeView = useSelector((state) => state.timeView);
 	const isListOpen = useSelector((state) => state.listOpen);
 
@@ -49,6 +50,24 @@ export const GanttGroup = ({ project }) => {
 				name: editedTask.name,
 			},
 		});
+		if (userData[0].photoLink !== null) {
+			fetch(
+				`https://www.googleapis.com/calendar/v3/calendars/primary/events/${editedTask.id.replace(
+					/-/g,
+					''
+				)}`,
+				{
+					method: 'PATCH',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${userData[0].accessToken}`,
+					},
+					body: JSON.stringify({
+						summary: editedTask.name,
+					}),
+				}
+			);
+		}
 		dispatch(editTaskNameInGanttData(editedTask));
 	};
 

--- a/src/component/InputArea/index.jsx
+++ b/src/component/InputArea/index.jsx
@@ -84,9 +84,6 @@ const InputArea = () => {
 				},
 			});
 			dispatch(addTaskIntoGanttData(taskData));
-			console.log(taskData, 'taskData');
-			console.log(taskData.start.toISOString().split('T')[0]);
-			console.log(taskData.end.toISOString().split('T')[0]);
 			const aDay = 24 * 60 * 60 * 1000;
 			const startDateCalendar = new Date(taskData.start.getTime() + aDay)
 				.toISOString()
@@ -105,6 +102,7 @@ const InputArea = () => {
 						},
 						body: JSON.stringify({
 							summary: taskData.name,
+							id: taskData.id.replace(/-/g, ''),
 							description: `This ${taskData.type} was added by Gantt Chart App automatically.`,
 							start: {
 								date: startDateCalendar,


### PR DESCRIPTION
問題：
1. 用戶更改 task 名稱時，Google Calendar 對應 Event 的名稱不會更改。

原因：
1. 沒有設置對應 API 來更新 Google Calendar Event 名稱。
2. 新增 Google Calendar Event 時，並沒有規範 id。

解決辦法：
1. 在更改 task 名稱的同時，使用 PATCH method 來更新 Google Calendar 對應 Event 名稱。
2. 新增 Google Calendar Event 的時候，就將其 id 設定為 task id 去除 Hyphen（因為 Event id 須符合 RFC-2938 的 base32 十六進位編碼字元規範，故去除 Hyphen）