### PR TITLE
GC-102 feat：刪除 task/project 時一併刪除 Calendar Events

### DIFF
--- a/src/component/GanttArea/GanttGroup.js
+++ b/src/component/GanttArea/GanttGroup.js
@@ -27,11 +27,27 @@ export const GanttGroup = ({ project }) => {
 	const deleteTaskHandler = (task) => {
 		console.log(task, 'task');
 		const conf = window.confirm(`Are you sure about delete ${task.name} ?`);
-		!!conf &&
+		if (!!conf) {
 			API.del('ganttTasksApi', `/gantttasks/userId/${task.id}`, {
 				response: true,
-			}).then((response) => console.log(response, 'from del API')) &&
+			}).then((response) => console.log(response, 'from del API'));
+			if (userData[0].photoLink !== null) {
+				fetch(
+					`https://www.googleapis.com/calendar/v3/calendars/primary/events/${task.id.replace(
+						/-/g,
+						''
+					)}`,
+					{
+						method: 'DELETE',
+						headers: {
+							'Content-Type': 'application/json',
+							Authorization: `Bearer ${userData[0].accessToken}`,
+						},
+					}
+				);
+			}
 			dispatch(deleteTaskFromGanttData(task));
+		}
 	};
 
 	const editTaskHandler = (task) => {

--- a/src/component/Sidebar/ChangeList/DeleteButton.js
+++ b/src/component/Sidebar/ChangeList/DeleteButton.js
@@ -8,6 +8,7 @@ import { deleteProjectCat } from '../../../store/projectCatSlice';
 
 export default function DeleteButton({ project }) {
 	const dispatch = useDispatch();
+	const userData = useSelector((state) => state.userData.userData);
 	const ganttTasksData = useSelector((state) => state.ganttDataRedux);
 	const catDeleteHandler = (e) => {
 		console.log('try to delete so hard...');
@@ -19,6 +20,21 @@ export default function DeleteButton({ project }) {
 			(thisProject) => thisProject.id === project.id
 		);
 		delProjectData[0].list.forEach((task) => {
+			if (userData[0].photoLink !== null) {
+				fetch(
+					`https://www.googleapis.com/calendar/v3/calendars/primary/events/${task.id.replace(
+						/-/g,
+						''
+					)}`,
+					{
+						method: 'DELETE',
+						headers: {
+							'Content-Type': 'application/json',
+							Authorization: `Bearer ${userData[0].accessToken}`,
+						},
+					}
+				);
+			}
 			API.del('ganttTasksApi', `/gantttasks/userId/${task.id}`, {
 				response: true,
 			}).then((response) => console.log(response, 'from del task API'));


### PR DESCRIPTION
問題：
1. 用戶刪除 task / project 時，Google Calendar Events 不會一同刪除。

原因：
1. 沒有設置 DELETE events API。

解決方法：
1. 在用戶刪除單一 task 的時候，同時發送 DELETE method 給 Google Calendar API。
2. 在用戶刪除 project 時，同時發送 DELETE method 給 Google Calendar API。