### PR TITLE
GC-103 feat：使用者重新 loading 時會檢查憑證是否過期

### DIFF
--- a/src/component/Sidebar/Sidebar.js
+++ b/src/component/Sidebar/Sidebar.js
@@ -49,14 +49,36 @@ const Sidebar = () => {
 	const navigate = useNavigate();
 	const isDataFetchedRef = useRef(false);
 
+	const logOutHandler = () => {
+		signOut();
+		navigate('/login');
+	};
+
 	useEffect(() => {
 		if (isDataFetchedRef.current) return;
 		const fetchData = async () => {
+			const username = user.username;
+			if (username.indexOf('google') !== -1) {
+				let expiryTime = await localStorage.getItem('gapiExpiryTime');
+				const currentDate = new Date().getTime();
+				if (expiryTime === 'null' || expiryTime === null) {
+					let expiredAt = 3500;
+					expiryTime = new Date(currentDate + expiredAt * 1000).getTime();
+					localStorage.setItem('gapiExpiryTime', expiryTime);
+				}
+				if (
+					Number(expiryTime) <= currentDate ||
+					expiryTime === null ||
+					expiryTime === 'null'
+				) {
+					localStorage.setItem('gapiExpiryTime', null);
+					logOutHandler();
+				}
+			}
 			dispatch(fetchCats());
 			dispatch(fetchUserData());
 			await dispatch(fetchCatsToGantt());
 			await dispatch(fetchTasksToGantt());
-			const username = user.username;
 			if (userData.userData.length !== 0) {
 				if (username.indexOf('google') === -1) {
 					const newUser = {
@@ -109,11 +131,6 @@ const Sidebar = () => {
 		fetchData();
 		isDataFetchedRef.current = true;
 	}, []);
-
-	const logOutHandler = () => {
-		signOut();
-		navigate('/login');
-	};
 
 	return (
 		<Drawer


### PR DESCRIPTION
問題：
1. Google 登入的使用者過一定時間後，無法處理 task，因為 Google OAuth 憑證到期。

原因：
1. Google 登入的使用者每過 1 小時，access token 的憑證就會到期，因此才會發生無法串接 Google Calendar API 的問題。

解決辦法：
1. Google 使用者登入後，會優先檢查 localStorage 有無「gapiExpiryTime」這一 item；
2. 若「無」，則會新增「現在時間 + 3500 秒」至 localStorage 中；
3. 若「有」，則會檢查與現在時間相比是否過期： 　- 過期：將 localStorage 該 item 設定為 null，接著登出；
　- 未過期：讓使用者正常登入。